### PR TITLE
feat: add a minimal .gitignore for the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+### Fichier `.gitignore` générique pour les projets HTML, CSS et JavaScript
+
+# Ce fichier de configuration est utilisé dans un projet versionné avec Git pour spécifier
+# quels fichiers ou dossiers ne doivent pas être suivis ou inclus dans le contrôle de version.
+# Il est placé à la racine du dépôt Git ou dans des sous-dossiers spécifiques, et liste des motifs
+# correspondant aux noms de fichiers ou répertoires à ignorer.
+#
+# Aide en ligne : https://git-scm.com/docs/gitignore/fr
+
+### Ignorer les dossiers de configuration spécifiques aux IDE
+
+# Dossier JetBrains et Visual Studio Code
+.idea/
+.vscode/
+
+
+### Ignorer les fichiers générés par l'OS
+
+# Fichiers et dossiers temporaires de macOS
+.DS_Store
+
+# Fichiers de cache de Windows
+Thumbs.db
+ehthumbs.db
+
+
+### Ignorer les fichiers de log et de sauvegarde
+
+*.log
+*.tmp
+*.bak


### PR DESCRIPTION
The `.gitignore` file in this project is used to specify which files and directories Git should ignore, preventing them from being tracked in the repository. This helps in keeping the repository clean and focused on the essential codebase. Specifically, it excludes:

- **IDE Configuration Files**: Directories like `.idea/` (JetBrains) and `.vscode/` (Visual Studio Code) are ignored, as they contain user-specific settings that are not relevant to the project as a whole.
  
- **System-Specific Files**: Files like `.DS_Store` (macOS) and `Thumbs.db` (Windows) are excluded, as they are generated automatically by the operating system and do not contribute to the project.

- **Log Files and Temporary Files**: Files such as `*.log` and `*.tmp` are ignored to avoid clutter in the repository with temporary or log data.

This ensures that only the relevant source code and configuration files are tracked, simplifying collaboration and maintaining the repository's integrity.
